### PR TITLE
add 4 new scripts to be used for installing gt4gemstone into a 3.7.1 or 3.7.1.4 gemstone rowan3 extent

### DIFF
--- a/scripts/convertToGsFormat_rowan3.sh
+++ b/scripts/convertToGsFormat_rowan3.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+### Export gt4gemstone to a .gs file.
+### Requires loginSystemUser.topaz be configured with the correct credentials,
+### and the environmental variable STONE to indicate the target stone name.
+### Exits with 0 if success, topaz status if failed.
+
+set -e
+
+if [ -z "$ROWAN_PROJECTS_HOME" ]
+then
+	echo "ROWAN_PROJECTS_HOME must be defined"
+	exit 1
+fi
+
+if [ -z "$STONE" ]
+then
+	echo "STONE must be defined"
+	exit 1
+fi
+
+gt4GemstoneHome=${ROWAN_PROJECTS_HOME}/gt4gemstone
+## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
+topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/convertToGsFormat_rowan3.topaz < /dev/zero
+status=$?
+if [ $status != 0 ]
+then
+        echo !!!!!!!!!!!!!!!!
+        echo Failed to export gt4gemstone
+        echo !!!!!!!!!!!!!!!!
+        exit $status
+fi
+
+exit 0

--- a/scripts/convertToGsFormat_rowan3.topaz
+++ b/scripts/convertToGsFormat_rowan3.topaz
@@ -1,0 +1,45 @@
+	iferr 1 stk
+	iferr 2 stack
+	iferr 3 exit
+
+	expectvalue true
+	run
+| warnings projectSetModification visitor gsDirectory project repositoryRoot projectSetDefinition  |
+warnings := String new.
+
+	repositoryRoot := '$ROWAN_PROJECTS_HOME/gt4gemstone'.
+	gsDirectory := repositoryRoot asFileReference / 'src-gs'.
+	project := Rowan 
+		projectFromUrl: 'file:', repositoryRoot, '/rowan/specs/gt4gemstone.ston'
+		gitUrl: 'file:', repositoryRoot.
+	projectSetDefinition := RwProjectSetDefinition new
+		addProject: project _concreteProject;
+		yourself.
+	projectSetModification := projectSetDefinition compareAgainstBase: RwProjectSetDefinition new.
+
+	projectSetModification findAddedMethods values do: [ :each |
+		each methodsModification elementsModified values do: [ :another | 
+			another after protocol: another after protocol asString ] ].
+
+	projectSetModification findAddedClasses values do: [ :each |
+		each classesModification elementsModified values collect: [ :another | 
+			another after instanceMethodDefinitions values do: [ :aMethodDefinition |
+				aMethodDefinition protocol: aMethodDefinition protocol asString ].
+			another after classMethodDefinitions values do: [ :aMethodDefinition |
+				aMethodDefinition protocol: aMethodDefinition protocol asString ] ] ].
+
+	visitor := RwGsModificationTopazWriterVisitorV2 new
+		logCreation: true;
+		repositoryRootPath: gsDirectory;
+		topazFilename: 'gt4gemstone';
+		yourself.
+	visitor visit: projectSetModification.
+
+
+warnings isEmpty
+	ifTrue: [ true ]
+	ifFalse: [ warnings ]
+%
+	abort
+
+	errorCount

--- a/scripts/installGt4gemstone_rowan3_jfp.sh
+++ b/scripts/installGt4gemstone_rowan3_jfp.sh
@@ -29,7 +29,7 @@ if [ $? = 0 ]
         exit 1
     fi
 
-## Update 3.7.1 and 3.7.1.4 for use with a Rowan 3 image and JadeiteForPharo
+## Update for 3.7.1 and 3.7.1.4 Rowan 3 image and JadeiteForPharo
 #
 ## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
 topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/updateForRowan3_JfP-gemstone.topaz < /dev/zero

--- a/scripts/installGt4gemstone_rowan3_jfp.sh
+++ b/scripts/installGt4gemstone_rowan3_jfp.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+### Install gt4gemstone from Tonel files into a Rowan-enabled stone
+### Exits with 0 if success, 1 if failed
+
+set -e
+
+if [ -z "$ROWAN_PROJECTS_HOME" ]
+then
+	echo "ROWAN_PROJECTS_HOME must be defined"
+	exit 1
+fi
+
+if [ -z "$STONE" ]
+then
+	echo "STONE must be defined"
+	exit 1
+fi
+
+gt4GemstoneHome=${ROWAN_PROJECTS_HOME}/gt4gemstone
+## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
+topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/installGtoolkit-gemstone.topaz < /dev/zero
+if [ $? = 0 ]
+    then
+        echo gt4gemstone loaded, now updating Rowan3 extent for use with JfP
+    else
+        echo !!!!!!!!!!!!!!
+        echo INSTALL FAILED for gt4gemstone
+        echo !!!!!!!!!!!!!!
+        exit 1
+    fi
+
+## Update 3.7.1 and 3.7.1.4 for use with a Rowan 3 image and JadeiteForPharo
+#
+## Topaz refuses to exit from script if input is stdin, so redirect from /dev/zero
+topaz -l -I ${gt4GemstoneHome}/scripts/loginSystemUser.topaz  -S ${gt4GemstoneHome}/scripts/updateForRowan3_JfP-gemstone.topaz < /dev/zero
+if [ $? = 0 ]
+    then
+        exit 0
+    else
+        echo !!!!!!!!!!!!!!
+        echo INSTALL FAILED for Rowan 3 JfP update
+        echo !!!!!!!!!!!!!!
+        exit 1
+    fi
+

--- a/scripts/updateForRowan3_JfP-gemstone.topaz
+++ b/scripts/updateForRowan3_JfP-gemstone.topaz
@@ -1,0 +1,50 @@
+	iferr 1 stk
+	iferr 2 stack
+	iferr 3 exit
+
+	expectvalue true
+	run
+| warnings rowanProjectsHome |
+warnings := String new.
+rowanProjectsHome := '$ROWAN_PROJECTS_HOME'.
+[
+	"update RowanClientServices:mainV3.0 [3d1ae497b] (as of 9/5/24) -- REQUIRED for JfP"
+true ifTrue: [ 
+	"temporary patch to ensure 'mainV3.0' branch is used"
+	| spec |
+	spec := RwSpecification fromUrl: 'https://raw.githubusercontent.com/GemTalk/RowanClientServices/masterV3.0/rowan/specs/RowanClientServices.ston'.
+	spec 
+		revision: 'mainV3.0';
+		projectsHome: rowanProjectsHome;
+		load
+] ifFalse: [
+	(Rowan projectFromUrl: 'https://raw.githubusercontent.com/GemTalk/RowanClientServices/masterV3.0/rowan/specs/RowanClientServices.ston')
+		projectsHome: rowanProjectsHome;
+		load ].
+
+	"update RemoteServiceReplication:main [04f33cab2] (as of 9/5/24) -- REQUIRED for JfP"
+true ifTrue: [ 
+	"temporary patch to ensure 'main' branch is used"
+	| spec |
+	spec := RwSpecification fromUrl: 'https://raw.githubusercontent.com/GemTalk/RemoteServiceReplication/main/rowan/specs/RemoteServiceReplication.ston'.
+	spec 
+		revision: 'main';
+		projectsHome: rowanProjectsHome;
+		load
+] ifFalse: [
+	(Rowan projectFromUrl: 'https://raw.githubusercontent.com/GemTalk/RemoteServiceReplication/main/rowan/specs/RemoteServiceReplication.ston')
+		projectsHome: rowanProjectsHome;
+		load.
+] ] on: CompileWarning do: [:ex |
+	(ex description includesString: 'not optimized')
+			ifFalse: [ warnings 
+                           addAll: ex asString;
+                           lf ].
+	ex resume ].
+warnings isEmpty
+	ifTrue: [ true ]
+	ifFalse: [ warnings ]
+%
+	commit
+
+	errorCount


### PR DESCRIPTION
updateForRowan3_JfP-gemstone.topaz is used to update RowanClientServices and RemoteServiceReplication in the stone. It is called by the new installGt4gemstone_rowan3_jfp.sh script. The new versions of RowanClientServices and RemoteServiceReplication are needed by JadeiteForPharo (JfP).

convertToGsFormat_rowan3.topaz contains a modification to the script for use with Rowan 3 and is called by convertToGsFormat_rowan3.sh.

The scripts have been tested with 3.7.1 and 3.7.1.4 ... and the latest [JadeiteForPharo](https://github.com/GemTalk/JadeiteForPharo).

Here are the SHAS of the JadeiteForPharo projects I was using:
```
JadeiteForPharo 06ee1e8
PharoGemStoneFFI 3575de4
RemoteServiceReplication 04f33ca
---------------------------------------------
RowanClientServices 3d1ae49
```
Use the `Git Commit Ids` menu on the Jadeite Connection Launcher:
![image](https://github.com/user-attachments/assets/a3828dd2-57e1-474a-9ed9-fb427b8e2ab2)
to verify the SHAS that you are using.
```