### PR TITLE
fix issue: VM temporary object memory is full , old space overflow 

### DIFF
--- a/scripts/release/inputRelease.topaz
+++ b/scripts/release/inputRelease.topaz
@@ -3,12 +3,19 @@
 	iferr 3 exit
 
 	input $GT4GEMSTONE_RELEASE_HOME/gt4gemstone/src-gs/Announcements.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/gt4gemstone/src-gs/RemoteServiceReplication.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/gt4gemstone/src-gs/STON.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/gt4gemstone/src-gs/patch-gemstone.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/gtoolkit-wireencoding/src-gs/gtoolkit-wireencoding.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/gt4gemstone/src-gs/gt4gemstone.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/gtoolkit-remote/src-gs/gtoolkit-remote.gs
+	commit
 	input $GT4GEMSTONE_RELEASE_HOME/inputVersion.topaz
 	commit
 


### PR DESCRIPTION
This PR fix the OOM issue. In some GS 3.7.5 databases the installation fail with :

OutOfMemory old space overflow at 134 scavenges 97 markSweeps 0 pomGenScavenges
(vmGc OOM   97 OOM 2614/2944Knew 37439/37440Kold 10490Kpom 5042Kperm  150Kmeths  182KmethsNcode    5Kdoits    8KdoitsNcode 6733Kme    0Kffi pomDirtyBytes 0 pomThresh 1 ldirty 3981 export 767
 vmGc   pom0:4155K pom1:4159K pom2:2176K
--- 04/21/2026 16:54:49.158 CEST Logging out
-----------------------------------------------------
GemStone: Error         Fatal
VM temporary object memory is full
, old space overflow
Error Category: 231169 [GemStone] Number: 4067  Arg Count: 1 Context : 20 exception : 20
