### PR TITLE
remove requirement for package-release.sh to be run in *.image dir

### DIFF
--- a/scripts/release/package-release.sh
+++ b/scripts/release/package-release.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-ls *.image
-status_ls=$?
-if [ $status_ls -ne 0 ]
-then
-  echo "No image file found.  CWD should be the image directory."
-  exit 1
-fi
-imageDirectory=$(pwd)
-
 if [ -z "$ROWAN_PROJECTS_HOME" ]
 then
 	echo "ROWAN_PROJECTS_HOME must be defined"


### PR DESCRIPTION
Being dependent on *.image directory execution does not appear to be required by this script. The motivation to remove this requirement is so external scripts (like the one I'm writing) can build a release of gt4gemstone for a devkit stone without the requirement of having GT installed.