### PR TITLE
Small coherence fix on GspoString

### DIFF
--- a/src/GToolkit-GemStone-Pharo/AbstractDictionary.class.st
+++ b/src/GToolkit-GemStone-Pharo/AbstractDictionary.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #AbstractDictionary,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/ClassOrganizer.class.st
+++ b/src/GToolkit-GemStone-Pharo/ClassOrganizer.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #ClassOrganizer,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/CompileError.class.st
+++ b/src/GToolkit-GemStone-Pharo/CompileError.class.st
@@ -6,5 +6,5 @@ It allows GemStone classes to be loaded in Gtoolkit without undefined class erro
 Class {
 	#name : #CompileError,
 	#superclass : #Error,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/GsCurrentSession.class.st
+++ b/src/GToolkit-GemStone-Pharo/GsCurrentSession.class.st
@@ -6,5 +6,5 @@ It allows GemStone classes to be loaded in Gtoolkit without undefined class erro
 Class {
 	#name : #GsCurrentSession,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/GspoByteArray.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoByteArray.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoByteArray,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoCharacter.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoCharacter.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoCharacter,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoDictionary.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoDictionary.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoDictionary,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoGtRmGeoGpsRecord.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoGtRmGeoGpsRecord.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoGtRmGeoGpsRecord,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-GeolifeDemo'
+	#category : 'GToolkit-GemStone-Pharo-GeolifeDemo'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoGtRmGeoGpsTrajectory.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoGtRmGeoGpsTrajectory.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoGtRmGeoGpsTrajectory,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-GeolifeDemo'
+	#category : 'GToolkit-GemStone-Pharo-GeolifeDemo'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoGtRmGeoUser.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoGtRmGeoUser.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoGtRmGeoUser,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-GeolifeDemo'
+	#category : 'GToolkit-GemStone-Pharo-GeolifeDemo'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoGtRmGeolife.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoGtRmGeolife.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoGtRmGeolife,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-GeolifeDemo'
+	#category : 'GToolkit-GemStone-Pharo-GeolifeDemo'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoRowanProjectService.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoRowanProjectService.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'name'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoSmallFraction.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoSmallFraction.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoSmallFraction,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GspoString.class.st
+++ b/src/GToolkit-GemStone-Pharo/GspoString.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GspoString,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }
@@ -95,7 +95,7 @@ GspoString >> limitedDisplayString [
 	^ self evaluateAndWait:
 'self size < 10000
 	ifTrue: [ self ]
-	ifFalse: [ (self copyFrom: 1 to: 997), ''...'' ]'
+	ifFalse: [ (self copyFrom: 1 to: 9997), ''...'' ]'
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneActivatedSessionViewModelChanged.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneActivatedSessionViewModelChanged.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'activatedSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Events'
+	#category : 'GToolkit-GemStone-Pharo-Events'
 }
 
 { #category : #generated }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneAnnouncement,
 	#superclass : #Announcement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncEvaluationElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncEvaluationElement.class.st
@@ -21,7 +21,7 @@ Class {
 		'replacePaneContentAutomatically',
 		'shouldReplaceContent'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }
 
 { #category : #callbacks }
@@ -125,6 +125,14 @@ GtGemStoneAsyncEvaluationElement >> buildStartTimeRow [
 ]
 
 { #category : #'building widgets' }
+GtGemStoneAsyncEvaluationElement >> buildToolbar [
+	^ BrToolbar new
+		aptitude: BrGlamorousToolbarAptitude new;
+		alignCenterLeft;
+		fitContent.
+]
+
+{ #category : #'building widgets' }
 GtGemStoneAsyncEvaluationElement >> buildToolLabel [
 	^(BrLabel new)
 		aptitude: ((BrGlamorousLabelAptitude new)
@@ -145,14 +153,6 @@ GtGemStoneAsyncEvaluationElement >> buildToolLabel [
 		hMatchParent;
 		vFitContent;
 		background: Color white
-]
-
-{ #category : #'building widgets' }
-GtGemStoneAsyncEvaluationElement >> buildToolbar [
-	^ BrToolbar new
-		aptitude: BrGlamorousToolbarAptitude new;
-		alignCenterLeft;
-		fitContent.
 ]
 
 { #category : #'building widgets' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncEvaluationPhlowTool.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncEvaluationPhlowTool.class.st
@@ -9,7 +9,7 @@ Class {
 		'EnableElapsedTimeUpdate',
 		'ReplacePaneContentAutomatically'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }
 
 { #category : #settings }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncExecution.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncExecution.class.st
@@ -5,7 +5,7 @@ Class {
 		'asyncPromise',
 		'promiseResolution'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolution.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolution.class.st
@@ -9,7 +9,7 @@ Class {
 		'state',
 		'asyncPromise'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }
 
 { #category : #callbacks }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolutionAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolutionAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneAsyncPromiseResolutionAnnouncement,
 	#superclass : #Announcement,
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolutionFinishedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolutionFinishedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneAsyncPromiseResolutionFinishedAnnouncement,
 	#superclass : #GtGemStoneAsyncPromiseResolutionAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolutionStartedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneAsyncPromiseResolutionStartedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneAsyncPromiseResolutionStartedAnnouncement,
 	#superclass : #GtGemStoneAsyncPromiseResolutionAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCardWidgetNoSessions.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCardWidgetNoSessions.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneCardWidgetNoSessions,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassCategoryChangeCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassCategoryChangeCodeSyncSignal.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneClassCategoryChangeCodeSyncSignal,
 	#superclass : #GtGemStoneClassCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassCodeSyncSignal.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneClassCodeSyncSignal,
 	#superclass : #GtGemStoneCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #printing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassCommentCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassCommentCodeSyncSignal.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneClassCommentCodeSyncSignal,
 	#superclass : #GtGemStoneClassCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionCodeSyncSignal.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneClassDefinitionCodeSyncSignal,
 	#superclass : #GtGemStoneClassCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionDiffTab.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionDiffTab.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'contentSelector'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UiClassDefinition'
+	#category : 'GToolkit-GemStone-Pharo-UiClassDefinition'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionSourceTab.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionSourceTab.class.st
@@ -7,7 +7,7 @@ Class {
 		'compileLabel',
 		'existsSelector'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UiClassDefinition'
+	#category : 'GToolkit-GemStone-Pharo-UiClassDefinition'
 }
 
 { #category : #'private - actions' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionTab.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionTab.class.st
@@ -8,7 +8,7 @@ Class {
 		'label',
 		'classDefinitionWidget'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UiClassDefinition'
+	#category : 'GToolkit-GemStone-Pharo-UiClassDefinition'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionTool.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionTool.class.st
@@ -9,7 +9,7 @@ Class {
 		'gtDefinitionString',
 		'retrievedGsProxy'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'method  utilities' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionToolButtonId.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionToolButtonId.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneClassDefinitionToolButtonId,
 	#superclass : #GtCoderElementId,
-	#category : #'GToolkit-GemStone-Pharo-Coder - Ids'
+	#category : 'GToolkit-GemStone-Pharo-Coder - Ids'
 }
 
 { #category : #converting }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionWidget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassDefinitionWidget.class.st
@@ -7,7 +7,7 @@ Class {
 		'currentTab',
 		'toolbarContainer'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UiClassDefinition'
+	#category : 'GToolkit-GemStone-Pharo-UiClassDefinition'
 }
 
 { #category : #'private - ui' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassMigrator.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassMigrator.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'session'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Utilities'
+	#category : 'GToolkit-GemStone-Pharo-Utilities'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassRemovalCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassRemovalCodeSyncSignal.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'removed'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneClassRenameCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneClassRenameCodeSyncSignal.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneClassRenameCodeSyncSignal,
 	#superclass : #GtGemStoneClassCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSync.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSync.class.st
@@ -20,7 +20,7 @@ Class {
 		'registry',
 		'flusher'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #private }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncBasicEpEventStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncBasicEpEventStrategy.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneCodeSyncBasicEpEventStrategy,
 	#superclass : #GtGemStoneCodeSyncEpEventStrategy,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #ui }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncCategoriesStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncCategoriesStrategy.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'categories'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncClassStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncClassStrategy.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneCodeSyncClassStrategy,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #testing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncCustomClassStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncCustomClassStrategy.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'valuable'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #printing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncCustomSessionStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncCustomSessionStrategy.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'valuable'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #printing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncDefaultSessionStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncDefaultSessionStrategy.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneCodeSyncDefaultSessionStrategy,
 	#superclass : #GtGemStoneCodeSyncSessionStrategy,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncEpEventStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncEpEventStrategy.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneCodeSyncEpEventStrategy,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #'event handling' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncExamples.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncExamples.class.st
@@ -9,7 +9,7 @@ Class {
 		'logger',
 		'sessionId'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Examples'
+	#category : 'GToolkit-GemStone-Pharo-Examples'
 }
 
 { #category : #examples }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncExplicitClassStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncExplicitClassStrategy.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'classes'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncExplicitSessionStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncExplicitSessionStrategy.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'sessions'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncSessionStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncSessionStrategy.class.st
@@ -4,7 +4,7 @@ GtGemStoneCodeSyncSessionStrategy determines which sessions in the receiver's re
 Class {
 	#name : #GtGemStoneCodeSyncSessionStrategy,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #testing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncSignal.class.st
@@ -5,7 +5,7 @@ Class {
 		'change',
 		'session'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncStateSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncStateSignal.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneCodeSyncStateSignal,
 	#superclass : #GtGemStoneBeaconSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncSubclassClassStrategy.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneCodeSyncSubclassClassStrategy.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'superclass'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneConnector.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneConnector.class.st
@@ -17,7 +17,7 @@ Class {
 		'iconName',
 		'maxKeepAlive'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #'api - announcer' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorAnnouncement.class.st
@@ -14,7 +14,7 @@ Class {
 		'connector',
 		'operation'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorNameChangeAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorNameChangeAnnouncement.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneConnectorNameChangeAnnouncement,
 	#superclass : #GtGemStoneConnectorAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }
 
 { #category : #initialization }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorsWidget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorsWidget.class.st
@@ -6,17 +6,17 @@ Class {
 		'sessionsRegistry',
 		'actionCallback'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
-
-{ #category : #callbacks }
-GtGemStoneConnectorsWidget >> actOnConnectorSelected: aGemStoneConnector [ 
-	actionCallback value: aGemStoneConnector
-]
 
 { #category : #accessing }
 GtGemStoneConnectorsWidget >> actionCallback: aBlockClosure [
 	actionCallback := aBlockClosure
+]
+
+{ #category : #callbacks }
+GtGemStoneConnectorsWidget >> actOnConnectorSelected: aGemStoneConnector [ 
+	actionCallback value: aGemStoneConnector
 ]
 
 { #category : #'building widgets' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorsWidgetRebuildConnectorsButtonId.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneConnectorsWidgetRebuildConnectorsButtonId.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneConnectorsWidgetRebuildConnectorsButtonId,
 	#superclass : #BlElementUniqueId,
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDebugger.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDebugger.class.st
@@ -7,20 +7,20 @@ Class {
 		'announcer',
 		'allStackFrames'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
+
+{ #category : #announcer }
+GtGemStoneDebugger >> announcer [
+	<return: #Announcer>
+	^ announcer
+]
 
 { #category : #private }
 GtGemStoneDebugger >> announceStateChange [
 	"Announce that the receiver's state has changed"
 	
 	self announcer announce: (GtGemStoneDebuggerStateChanged new debugger: self)
-]
-
-{ #category : #announcer }
-GtGemStoneDebugger >> announcer [
-	<return: #Announcer>
-	^ announcer
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerElement.class.st
@@ -15,7 +15,7 @@ Class {
 		'sourceCodeEditorElement',
 		'debuggerMessageEditor'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #testing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerSession.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerSession.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneDebuggerSession,
 	#superclass : #GtDebugSession,
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerStackModel.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerStackModel.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneDebuggerStackModel,
 	#superclass : #GtDebuggerAbstractStackModel,
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerStateChanged.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerStateChanged.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'debugger'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerToolbar.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDebuggerToolbar.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'debuggerMessageEditor'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #callbacks }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDefaultSessionIdentifier.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDefaultSessionIdentifier.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneDefaultSessionIdentifier,
 	#superclass : #GtGemStoneSessionIdentifier,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #'lepiter-store' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneDirectConnector.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneDirectConnector.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'port'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneEvaluatorExamples.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneEvaluatorExamples.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #Object,
 	#traits : 'TAssertable',
 	#classTraits : 'TAssertable classTrait',
-	#category : #'GToolkit-GemStone-Pharo-Examples'
+	#category : 'GToolkit-GemStone-Pharo-Examples'
 }
 
 { #category : #examples }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneExpandableDebuggerElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneExpandableDebuggerElement.class.st
@@ -9,7 +9,7 @@ Class {
 		'stdoutEditor',
 		'toolbarElement'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #testing }
@@ -56,6 +56,14 @@ GtGemStoneExpandableDebuggerElement class >> sessionClass [
 ]
 
 { #category : #callbacks }
+GtGemStoneExpandableDebuggerElement >> actOnDebuggerStateChanged [
+
+	self debugSession synchronizeCallStack.
+	self currentCallFrame resetState.
+	self scheduleUpdateUI.
+]
+
+{ #category : #callbacks }
 GtGemStoneExpandableDebuggerElement >> actOnDebugSessionChanged [
 
 	toolbarElement actOnDebugSessionChanged.
@@ -64,14 +72,6 @@ GtGemStoneExpandableDebuggerElement >> actOnDebugSessionChanged [
 		send: #actOnDebuggerStateChanged
 		to: self.
 	
-	self scheduleUpdateUI.
-]
-
-{ #category : #callbacks }
-GtGemStoneExpandableDebuggerElement >> actOnDebuggerStateChanged [
-
-	self debugSession synchronizeCallStack.
-	self currentCallFrame resetState.
 	self scheduleUpdateUI.
 ]
 

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneExpandableDebuggerToolbar.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneExpandableDebuggerToolbar.class.st
@@ -10,7 +10,7 @@ Class {
 		'stepThroughButton',
 		'stepOutButton'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #callbacks }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneExpandableStackElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneExpandableStackElement.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'stackIndexList'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #callbacks }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneExplicitSessionIdentifier.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneExplicitSessionIdentifier.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'sessionName'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #'lepiter-store' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneGciConnector.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneGciConnector.class.st
@@ -11,7 +11,7 @@ Class {
 		'libraryPath',
 		'gemstoneVersion'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneGciConnectorViewModel.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneGciConnectorViewModel.class.st
@@ -7,7 +7,7 @@ Class {
 		'connector',
 		'propertiesFile'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneGciConnectorWidget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneGciConnectorWidget.class.st
@@ -5,7 +5,7 @@ Class {
 		'connectorViewModel',
 		'saveButton'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneIgnoredCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneIgnoredCodeSyncSignal.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneIgnoredCodeSyncSignal,
 	#superclass : #GtGemStoneCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneInspectorTool.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneInspectorTool.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneInspectorTool,
 	#superclass : #GtRemoteInspectorTool,
-	#category : #'GToolkit-GemStone-Pharo-Phlow Tool'
+	#category : 'GToolkit-GemStone-Pharo-Phlow Tool'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneKeepAliveNotification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneKeepAliveNotification.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'registry'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Notifications'
+	#category : 'GToolkit-GemStone-Pharo-Notifications'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneKeepAliveNotificationElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneKeepAliveNotificationElement.class.st
@@ -8,14 +8,8 @@ Class {
 		'statesPane',
 		'sessionList'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Notifications'
+	#category : 'GToolkit-GemStone-Pharo-Notifications'
 }
-
-{ #category : #accessing }
-GtGemStoneKeepAliveNotificationElement >> actOnElementDetached [
-	super actOnElementDetached.
-	self clearContent.
-]
 
 { #category : #'private - accessing' }
 GtGemStoneKeepAliveNotificationElement >> activeMark [
@@ -26,6 +20,12 @@ GtGemStoneKeepAliveNotificationElement >> activeMark [
 			c horizontal matchParent.
 			c vertical fitContent ];
 		addChild: (BrGlamorousVectorIcons accept asElement)
+]
+
+{ #category : #accessing }
+GtGemStoneKeepAliveNotificationElement >> actOnElementDetached [
+	super actOnElementDetached.
+	self clearContent.
 ]
 
 { #category : #'private - accessing' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneKeepAliveSession.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneKeepAliveSession.class.st
@@ -6,7 +6,7 @@ Class {
 		'dirtyCount',
 		'maxKeepAlive'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Registry'
+	#category : 'GToolkit-GemStone-Pharo-Registry'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneMethodCodeSyncSignal.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneMethodCodeSyncSignal.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneMethodCodeSyncSignal,
 	#superclass : #GtGemStoneCodeSyncSignal,
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneNullConnector.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneNullConnector.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneNullConnector,
 	#superclass : #GtGemStoneConnector,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStonePhlowInspectorObject.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStonePhlowInspectorObject.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStonePhlowInspectorObject,
 	#superclass : #GtRemotePhlowInspectorObject,
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #configuring }

--- a/src/GToolkit-GemStone-Pharo/GtGemStonePostMortemDebugger.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStonePostMortemDebugger.class.st
@@ -6,7 +6,7 @@ Class {
 		'session',
 		'stackFrames'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStonePostMortemStackFrame.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStonePostMortemStackFrame.class.st
@@ -9,7 +9,7 @@ Class {
 		'sourceCode',
 		'method'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStonePropertiesFile.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStonePropertiesFile.class.st
@@ -8,7 +8,7 @@ The properties file is not normally manipulated directly, but through the regist
 Class {
 	#name : #GtGemStonePropertiesFile,
 	#superclass : #GtPropertiesFile,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #adding }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneRemoteProfileWrapper.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneRemoteProfileWrapper.class.st
@@ -7,7 +7,7 @@ Class {
 	#classInstVars : [
 		'current'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Utilities'
+	#category : 'GToolkit-GemStone-Pharo-Utilities'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneRemoteSessionFeatures.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneRemoteSessionFeatures.class.st
@@ -7,7 +7,7 @@ Class {
 		'featuresProxy',
 		'remoteFeaturesComputation'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #'instance  creation' }
@@ -52,17 +52,17 @@ GtGemStoneRemoteSessionFeatures >> enableFeatureWithId: aFeatureId [
 		ifAbsent: [ Error signal: 'Feature not found' ] 
 ]
 
+{ #category : #accessing }
+GtGemStoneRemoteSessionFeatures >> featuresProxy [
+	^ featuresProxy
+]
+
 { #category : #enumerating }
 GtGemStoneRemoteSessionFeatures >> featureWithId: aFeatureId ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
 	^ remoteFeatures
 		detect: [ :aFeature | aFeature featureId = aFeatureId] 
 		ifFound: aPresentBlock 
 		ifNone: anAbsentBlock
-]
-
-{ #category : #accessing }
-GtGemStoneRemoteSessionFeatures >> featuresProxy [
-	^ featuresProxy
 ]
 
 { #category : #accessing }
@@ -199,6 +199,13 @@ GtGemStoneRemoteSessionFeatures >> remoteFeatures [
 ]
 
 { #category : #utils }
+GtGemStoneRemoteSessionFeatures >> retrieveRemoteFeatures [
+	^ (self retrieveRemoteFeatureSpecifications )
+		collect: [ :aFeatureSpecification |
+			GtGemStoneSessionFeature fromFeatureSpecification: aFeatureSpecification ] 
+]
+
+{ #category : #utils }
 GtGemStoneRemoteSessionFeatures >> retrieveRemoteFeatureSpecifications [
 	^ (self retrieveRemoteFeatureSpecificationsData at: 'featureSpecifications')
 		collect: [ :featureData |
@@ -214,13 +221,6 @@ GtGemStoneRemoteSessionFeatures >> retrieveRemoteFeatureSpecificationsData [
 			autoCommit: false;
 			returnPrimitiveOnly;
 			evaluateAndWait) 
-]
-
-{ #category : #utils }
-GtGemStoneRemoteSessionFeatures >> retrieveRemoteFeatures [
-	^ (self retrieveRemoteFeatureSpecifications )
-		collect: [ :aFeatureSpecification |
-			GtGemStoneSessionFeature fromFeatureSpecification: aFeatureSpecification ] 
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneRemoteTranscript.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneRemoteTranscript.class.st
@@ -5,7 +5,7 @@ Class {
 		'gemStoneSession',
 		'transcriptProxy'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Transcript'
+	#category : 'GToolkit-GemStone-Pharo-Transcript'
 }
 
 { #category : #'instance creation' }
@@ -88,6 +88,19 @@ GtGemStoneRemoteTranscript >> gtActionInspectProxyFor: anAction [
 ]
 
 { #category : #'gt - extensions' }
+GtGemStoneRemoteTranscript >> gtActionsGsSessionFor: anAction [
+	<gtAction>
+	<gtToolAction>
+	
+	^(anAction dropdown)
+		label: 'GS Session';
+		withDropdownIndicator;
+		priority: 20;
+		items: [ :dropdownButton :aHostElement :aMenu |
+			self addSessionActionsOnMenu: aMenu ].
+]
+
+{ #category : #'gt - extensions' }
 GtGemStoneRemoteTranscript >> gtActionToggleFor: anAction [
 	<gtAction>
 	<gtToolAction>
@@ -116,19 +129,6 @@ GtGemStoneRemoteTranscript >> gtActionUpdateFor: anAction [
 		priority: 15;
 		action: [ :aButton |
 			aButton phlow fireCurrentToolUpdateWish ]
-]
-
-{ #category : #'gt - extensions' }
-GtGemStoneRemoteTranscript >> gtActionsGsSessionFor: anAction [
-	<gtAction>
-	<gtToolAction>
-	
-	^(anAction dropdown)
-		label: 'GS Session';
-		withDropdownIndicator;
-		priority: 20;
-		items: [ :dropdownButton :aHostElement :aMenu |
-			self addSessionActionsOnMenu: aMenu ].
 ]
 
 { #category : #'gt - extensions' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSelectedSessionViewModelChanged.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSelectedSessionViewModelChanged.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'selectedSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Events'
+	#category : 'GToolkit-GemStone-Pharo-Events'
 }
 
 { #category : #generated }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSerialisationManager.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSerialisationManager.class.st
@@ -4,7 +4,7 @@ Convenience methods for managing serialisation
 Class {
 	#name : #GtGemStoneSerialisationManager,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #replication }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSession.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSession.class.st
@@ -33,7 +33,7 @@ Class {
 		'sessionNrsString',
 		'sessionParameters'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAbortedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAbortedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionAbortedAnnouncement,
 	#superclass : #GtGemStoneSessionChangedAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionActionTarget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionActionTarget.class.st
@@ -4,7 +4,7 @@ Class {
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAddedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAddedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionAddedAnnouncement,
 	#superclass : #GtGemStoneSessionAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAnnouncement.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'session'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAutoCommitWidget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionAutoCommitWidget.class.st
@@ -6,7 +6,7 @@ Class {
 		'toggleButton',
 		'statusList'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #intialization }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionChangedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionChangedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionChangedAnnouncement,
 	#superclass : #GtGemStoneSessionAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCodeSync.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCodeSync.class.st
@@ -10,7 +10,7 @@ Class {
 		'enabled',
 		'gtSession'
 	],
-	#category : #'GToolkit-GemStone-Pharo-CodeSync'
+	#category : 'GToolkit-GemStone-Pharo-CodeSync'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCodeSyncWidget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCodeSyncWidget.class.st
@@ -6,7 +6,7 @@ Class {
 		'toggleButton',
 		'statusList'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCommitFailedError.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCommitFailedError.class.st
@@ -5,7 +5,7 @@ Class {
 		'transactionConflictsReport',
 		'transactionConflicts'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCommittedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionCommittedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionCommittedAnnouncement,
 	#superclass : #GtGemStoneSessionChangedAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionConnectedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionConnectedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionConnectedAnnouncement,
 	#superclass : #GtGemStoneSessionChangedAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionDefaultAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionDefaultAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionDefaultAnnouncement,
 	#superclass : #GtGemStoneSessionAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionDisconnectedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionDisconnectedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionDisconnectedAnnouncement,
 	#superclass : #GtGemStoneSessionChangedAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionError.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionError.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'gemStoneSession'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionIdentifier.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionIdentifier.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneSessionIdentifier,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #'lepiter-store' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionKeepAlive.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionKeepAlive.class.st
@@ -25,7 +25,7 @@ Class {
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Registry'
+	#category : 'GToolkit-GemStone-Pharo-Registry'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionLifecycleHandler.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionLifecycleHandler.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneSessionLifecycleHandler,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionLocator.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionLocator.class.st
@@ -5,7 +5,7 @@ Class {
 		'registry',
 		'identifier'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #converting }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionManagerViewModel.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionManagerViewModel.class.st
@@ -7,7 +7,7 @@ Class {
 		'gemStoneSessionsViewModel',
 		'announcer'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionRegistry.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionRegistry.class.st
@@ -31,7 +31,7 @@ Class {
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Registry'
+	#category : 'GToolkit-GemStone-Pharo-Registry'
 }
 
 { #category : #accessing }
@@ -1015,6 +1015,23 @@ GtGemStoneSessionRegistry >> sessionNamed: aString ifAbsent: absentBlock [
 	^ sessions at: aString ifAbsent: absentBlock
 ]
 
+{ #category : #private }
+GtGemStoneSessionRegistry >> sessions [ 
+
+	^ sessions
+]
+
+{ #category : #accessing }
+GtGemStoneSessionRegistry >> sessionsToDisplay [
+	"Answer the set of session names that should normally be displayed to users"
+	<return: #Array>
+
+	^ self activeSessions select: [ :aSession |
+		aSession isRunning or: [ 
+			aSession isDefaultSession or: [
+				aSession isBookmarked ] ] ]
+]
+
 { #category : #accessing }
 GtGemStoneSessionRegistry >> sessionWithConnection: aRsrConnection [
 	<return: #GtGemStoneSession>
@@ -1052,23 +1069,6 @@ GtGemStoneSessionRegistry >> sessionWithConnectorNamed: aString ifAbsent: absent
 		ifEmpty: absentBlock
 		ifNotEmpty: [ :sessionCollection |
 			(sessionCollection sorted: #sessionId ascending) first ].
-]
-
-{ #category : #private }
-GtGemStoneSessionRegistry >> sessions [ 
-
-	^ sessions
-]
-
-{ #category : #accessing }
-GtGemStoneSessionRegistry >> sessionsToDisplay [
-	"Answer the set of session names that should normally be displayed to users"
-	<return: #Array>
-
-	^ self activeSessions select: [ :aSession |
-		aSession isRunning or: [ 
-			aSession isDefaultSession or: [
-				aSession isBookmarked ] ] ]
 ]
 
 { #category : #initialization }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionRegistryBasicExamples.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionRegistryBasicExamples.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneSessionRegistryBasicExamples,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Examples'
+	#category : 'GToolkit-GemStone-Pharo-Examples'
 }
 
 { #category : #'examples - announcements' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionRemovedAnnouncement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionRemovedAnnouncement.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGemStoneSessionRemovedAnnouncement,
 	#superclass : #GtGemStoneSessionAnnouncement,
-	#category : #'GToolkit-GemStone-Pharo-Announcements'
+	#category : 'GToolkit-GemStone-Pharo-Announcements'
 }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionSelectionBadgeElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionSelectionBadgeElement.class.st
@@ -9,7 +9,7 @@ Class {
 		'extent',
 		'currentSessionDisplayLabelComputation'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionSelectionElement.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionSelectionElement.class.st
@@ -10,7 +10,7 @@ Class {
 		'currentSessionDisplayLabelComputation',
 		'identifierType'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #private }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionSelectionStencil.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionSelectionStencil.class.st
@@ -8,7 +8,7 @@ Class {
 		'currentSessionNameComputation',
 		'currentSessionDisplayLabelComputation'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'api - instantiation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModel.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModel.class.st
@@ -7,7 +7,7 @@ Class {
 		'parentGemStoneSessionsViewModel',
 		'announcer'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'api - activation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelActivated.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelActivated.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'gemStoneSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Events'
+	#category : 'GToolkit-GemStone-Pharo-Events'
 }
 
 { #category : #generated }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelDeactivated.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelDeactivated.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'gemStoneSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Events'
+	#category : 'GToolkit-GemStone-Pharo-Events'
 }
 
 { #category : #generated }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelDeselected.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelDeselected.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'gemStoneSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Events'
+	#category : 'GToolkit-GemStone-Pharo-Events'
 }
 
 { #category : #generated }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelSelected.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionViewModelSelected.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'gemStoneSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Events'
+	#category : 'GToolkit-GemStone-Pharo-Events'
 }
 
 { #category : #generated }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidget.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidget.class.st
@@ -6,7 +6,7 @@ Class {
 		'sessionList',
 		'elementUpdater'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'instance creation' }
@@ -31,11 +31,6 @@ GtGemStoneSessionsCardWidget class >> addToHomeSectionCardsContainer: cardsConta
 					c frame vertical alignCenter ]))
 ]
 
-{ #category : #callbacks }
-GtGemStoneSessionsCardWidget >> actOnGemStoneSessionAnnouncement [
-	self requestContentUpdate
-]
-
 { #category : #private }
 GtGemStoneSessionsCardWidget >> activeMark [
 
@@ -45,6 +40,11 @@ GtGemStoneSessionsCardWidget >> activeMark [
 			c horizontal matchParent.
 			c vertical fitContent ];
 		addChild: (BrGlamorousVectorIcons accept asElement)
+]
+
+{ #category : #callbacks }
+GtGemStoneSessionsCardWidget >> actOnGemStoneSessionAnnouncement [
+	self requestContentUpdate
 ]
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidgetAddSessionButtonId.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidgetAddSessionButtonId.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneSessionsCardWidgetAddSessionButtonId,
 	#superclass : #BlElementUniqueId,
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidgetInspectButtonId.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidgetInspectButtonId.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneSessionsCardWidgetInspectButtonId,
 	#superclass : #BlElementUniqueId,
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidgetRefreshButtonId.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsCardWidgetRefreshButtonId.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtGemStoneSessionsCardWidgetRefreshButtonId,
 	#superclass : #BlElementUniqueId,
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsViewModel.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneSessionsViewModel.class.st
@@ -9,7 +9,7 @@ Class {
 		'gemStoneSessionViewModels',
 		'announcer'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'api - active sessions' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneStackFrame.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneStackFrame.class.st
@@ -18,7 +18,7 @@ Class {
 		'frameIdentifier',
 		'programCounterMarkers'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneTestingSession.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneTestingSession.class.st
@@ -8,7 +8,7 @@ Class {
 		'commandHistory',
 		'state'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Examples'
+	#category : 'GToolkit-GemStone-Pharo-Examples'
 }
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtGemStoneTranscriptPhlowTool.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGemStoneTranscriptPhlowTool.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'remoteTranscript'
 	],
-	#category : #'GToolkit-GemStone-Pharo-UI'
+	#category : 'GToolkit-GemStone-Pharo-UI'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtGsStoreStringFlag.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtGsStoreStringFlag.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #GtGsStoreStringFlag,
 	#superclass : #DynamicVariable,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluation.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluation.class.st
@@ -9,7 +9,7 @@ Class {
 		'gtSession',
 		'isAsyncExecution'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluationException.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluationException.class.st
@@ -10,22 +10,12 @@ Class {
 		'debuggerClient',
 		'gemStonePromise'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Debugger'
+	#category : 'GToolkit-GemStone-Pharo-Debugger'
 }
 
 { #category : #accessing }
 GtRsrEvaluationException >> currentDebuggerState [
 	^ debuggerState
-]
-
-{ #category : #accessing }
-GtRsrEvaluationException >> debugResult [
-	^ debugResult
-]
-
-{ #category : #accessing }
-GtRsrEvaluationException >> debugResult: anObject [
-	debugResult := anObject
 ]
 
 { #category : #accessing }
@@ -51,6 +41,16 @@ GtRsrEvaluationException >> debuggerState [
 
 	^ debuggerState ifNil: [ 
 		debuggerState := self getDebuggerState ]
+]
+
+{ #category : #accessing }
+GtRsrEvaluationException >> debugResult [
+	^ debugResult
+]
+
+{ #category : #accessing }
+GtRsrEvaluationException >> debugResult: anObject [
+	debugResult := anObject
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorAsyncPromise.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorAsyncPromise.class.st
@@ -10,7 +10,7 @@ Class {
 		'serializationStrategy',
 		'evaluationMutex'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }
 
 { #category : #accessing }
@@ -155,18 +155,18 @@ GtRsrEvaluatorAsyncPromise >> printOn: aStream [
 		aStream << state ]
 ]
 
-{ #category : #resolving }
-GtRsrEvaluatorAsyncPromise >> resolveWithEvaluationResult: evaluationResult [ 
-	evaluationResult isEvaluationCancelledResult 
-		ifTrue: [ self breakWithEvaluationResult: evaluationResult ]
-		ifFalse: [ self fulfillWithEvaluationResult: evaluationResult ]
-]
-
 { #category : #accessing }
 GtRsrEvaluatorAsyncPromise >> resolvedValue [
 	self assert: [ value ~~ self ].
 	
 	^ value
+]
+
+{ #category : #resolving }
+GtRsrEvaluatorAsyncPromise >> resolveWithEvaluationResult: evaluationResult [ 
+	evaluationResult isEvaluationCancelledResult 
+		ifTrue: [ self breakWithEvaluationResult: evaluationResult ]
+		ifFalse: [ self fulfillWithEvaluationResult: evaluationResult ]
 ]
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorFeature.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorFeature.class.st
@@ -5,7 +5,7 @@ Class {
 		'featureId',
 		'attributes'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorFeatures.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorFeatures.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'features'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorFeaturesServiceClient.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorFeaturesServiceClient.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtRsrEvaluatorFeaturesServiceClient,
 	#superclass : #GtRsrEvaluatorFeaturesService,
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorPromise.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorPromise.class.st
@@ -9,7 +9,7 @@ Class {
 		'value',
 		'autoCommit'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Promises'
+	#category : 'GToolkit-GemStone-Pharo-Promises'
 }
 
 { #category : #'instance creation' }

--- a/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorServiceClient.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrEvaluatorServiceClient.class.st
@@ -5,7 +5,7 @@ Class {
 		'gtSession',
 		'versionedEvaluator'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #actions }

--- a/src/GToolkit-GemStone-Pharo/GtRsrPerformEvaluation.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrPerformEvaluation.class.st
@@ -5,7 +5,7 @@ Class {
 		'selector',
 		'arguments'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtRsrProxyServiceClient.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrProxyServiceClient.class.st
@@ -11,7 +11,7 @@ Class {
 	#classVars : [
 		'ObjectMap'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }
@@ -68,15 +68,6 @@ GtRsrProxyServiceClient class >> subclassForRemoteClass: aSymbol [
 		detect: [ :each | each remoteClassMatcher value: aSymbol ]
 		ifNone: [ nil ].
 
-]
-
-{ #category : #private }
-GtRsrProxyServiceClient >> _id: id connection: connection remoteSelf: anObject remoteClass: aString [
-
-	_id := id.
-	_connection := connection.
-	remoteSelf := anObject.
-	remoteClass := aString.
 ]
 
 { #category : #converting }
@@ -881,4 +872,13 @@ GtRsrProxyServiceClient >> withCacheSend: aMessage computation: aBlockClosure [
 GtRsrProxyServiceClient >> withUnarySelectorsCache [
 	cacheStrategy := (GtProxyCacheStrategy new)
 		matchAllUnarySelectors
+]
+
+{ #category : #private }
+GtRsrProxyServiceClient >> _id: id connection: connection remoteSelf: anObject remoteClass: aString [
+
+	_id := id.
+	_connection := connection.
+	remoteSelf := anObject.
+	remoteClass := aString.
 ]

--- a/src/GToolkit-GemStone-Pharo/GtRsrScriptEvaluation.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrScriptEvaluation.class.st
@@ -5,7 +5,7 @@ Class {
 		'script',
 		'frameContext'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #evaluating }

--- a/src/GToolkit-GemStone-Pharo/GtRsrVersion1501Evaluator.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrVersion1501Evaluator.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtRsrVersion1501Evaluator,
 	#superclass : #GtRsrVersionedEvaluator,
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtRsrVersionedEvaluator.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtRsrVersionedEvaluator.class.st
@@ -5,7 +5,7 @@ Class {
 		'serviceClient',
 		'features'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Services'
+	#category : 'GToolkit-GemStone-Pharo-Services'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoBehavior.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoBehavior.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoBehavior,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #initialization }

--- a/src/GToolkit-GemStone-Pharo/GtpoBlockClosure.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoBlockClosure.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoBlockClosure,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoClass.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoClass.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'comment'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoDateTime.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoDateTime.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoDateTime,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoExecBlock.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoExecBlock.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoExecBlock,
 	#superclass : #GtpoBlockClosure,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGsNMethod.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGsNMethod.class.st
@@ -6,7 +6,7 @@ Class {
 		'selector',
 		'inClassName'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtGemStoneEvaluationContext.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtGemStoneEvaluationContext.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtGemStoneEvaluationContext,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtGemStoneRPackage.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtGemStoneRPackage.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'name'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowColumnedListViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowColumnedListViewSpecification.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #GtpoGtPhlowViewSpecification,
 	#traits : 'TGlpoGtPhlowListingViewSpecification',
 	#classTraits : 'TGlpoGtPhlowListingViewSpecification classTrait',
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowColumnedTreeViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowColumnedTreeViewSpecification.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #GtpoGtPhlowViewSpecification,
 	#traits : 'TGlpoGtPhlowListingViewSpecification + TGlpoGtPhlowTreeViewSpecification',
 	#classTraits : 'TGlpoGtPhlowListingViewSpecification classTrait + TGlpoGtPhlowTreeViewSpecification classTrait',
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowDetailsViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowDetailsViewSpecification.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtPhlowDetailsViewSpecification,
 	#superclass : #GtpoGtPhlowViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #serialization }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowForwardViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowForwardViewSpecification.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtPhlowForwardViewSpecification,
 	#superclass : #GtpoGtPhlowViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowListViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowListViewSpecification.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #GtpoGtPhlowViewSpecification,
 	#traits : 'TGlpoGtPhlowListingViewSpecification',
 	#classTraits : 'TGlpoGtPhlowListingViewSpecification classTrait',
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTextEditorViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTextEditorViewSpecification.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtPhlowTextEditorViewSpecification,
 	#superclass : #GtpoGtPhlowTextualViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTextViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTextViewSpecification.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtPhlowTextViewSpecification,
 	#superclass : #GtpoGtPhlowTextualViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTextualViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTextualViewSpecification.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtPhlowTextualViewSpecification,
 	#superclass : #GtpoGtPhlowViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTreeViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowTreeViewSpecification.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #GtpoGtPhlowViewSpecification,
 	#traits : 'TGlpoGtPhlowListingViewSpecification + TGlpoGtPhlowTreeViewSpecification',
 	#classTraits : 'TGlpoGtPhlowListingViewSpecification classTrait + TGlpoGtPhlowTreeViewSpecification classTrait',
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtPhlowViewSpecification.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtPhlowViewSpecification.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtPhlowViewSpecification,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowDeclarativeBlockActionDataSource.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowDeclarativeBlockActionDataSource.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtRemotePhlowDeclarativeBlockActionDataSource,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowSequenceableCollectionIterator.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowSequenceableCollectionIterator.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtRemotePhlowSequenceableCollectionIterator,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowSpawnObjectWrapper.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowSpawnObjectWrapper.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtRemotePhlowSpawnObjectWrapper,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowViewedObject.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtRemotePhlowViewedObject.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtRemotePhlowViewedObject,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoGtRsrEvaluationExceptionInformation.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoGtRsrEvaluationExceptionInformation.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoGtRsrEvaluationExceptionInformation,
 	#superclass : #GtRsrProxyServiceClient,
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoMetaclass3.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoMetaclass3.class.st
@@ -4,7 +4,7 @@ Class {
 	#classVars : [
 		'DefaultDictionary'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Proxies'
+	#category : 'GToolkit-GemStone-Pharo-Proxies'
 }
 
 { #category : #accessing }
@@ -34,6 +34,13 @@ GtpoMetaclass3 class >> remoteClassName [
 	^ #Metaclass3
 ]
 
+{ #category : #accessing }
+GtpoMetaclass3 >> compiledMethodAt: selector [
+
+	^ self proxyPerform: #compiledMethodAt:
+		withArguments: { selector }.
+]
+
 { #category : #private }
 GtpoMetaclass3 >> compileFromTab: aTab [
 	"Update the receiver's definition based on the current editor contents"
@@ -54,13 +61,6 @@ GtpoMetaclass3 >> compileFromTab: aTab [
 
 { #category : #accessing }
 GtpoMetaclass3 >> compileMethod: source category: categoryName [
-]
-
-{ #category : #accessing }
-GtpoMetaclass3 >> compiledMethodAt: selector [
-
-	^ self proxyPerform: #compiledMethodAt:
-		withArguments: { selector }.
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/GtpoModule.class.st
+++ b/src/GToolkit-GemStone-Pharo/GtpoModule.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #GtpoModule,
 	#superclass : #GtpoBehavior,
-	#category : #'GToolkit-GemStone-Pharo-Client'
+	#category : 'GToolkit-GemStone-Pharo-Client'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/PrintStream.class.st
+++ b/src/GToolkit-GemStone-Pharo/PrintStream.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PrintStream,
 	#superclass : #WriteStream,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/SessionTemps.class.st
+++ b/src/GToolkit-GemStone-Pharo/SessionTemps.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #SessionTemps,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/SymbolDictionary.class.st
+++ b/src/GToolkit-GemStone-Pharo/SymbolDictionary.class.st
@@ -6,5 +6,5 @@ It allows GemStone classes to be loaded in Gtoolkit without undefined class erro
 Class {
 	#name : #SymbolDictionary,
 	#superclass : #IdentityDictionary,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/System.class.st
+++ b/src/GToolkit-GemStone-Pharo/System.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #System,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/SystemRepository.class.st
+++ b/src/GToolkit-GemStone-Pharo/SystemRepository.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #SystemRepository,
 	#superclass : #Object,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }

--- a/src/GToolkit-GemStone-Pharo/TGlpoGtPhlowListingViewSpecification.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGlpoGtPhlowListingViewSpecification.trait.st
@@ -1,6 +1,6 @@
 Trait {
 	#name : #TGlpoGtPhlowListingViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/TGlpoGtPhlowTreeViewSpecification.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGlpoGtPhlowTreeViewSpecification.trait.st
@@ -1,6 +1,6 @@
 Trait {
 	#name : #TGlpoGtPhlowTreeViewSpecification,
-	#category : #'GToolkit-GemStone-Pharo-Stubs'
+	#category : 'GToolkit-GemStone-Pharo-Stubs'
 }
 
 { #category : #accessing }

--- a/src/GToolkit-GemStone-Pharo/TGtWithActivatedSessionViewModel.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithActivatedSessionViewModel.trait.st
@@ -3,8 +3,17 @@ Trait {
 	#instVars : [
 		'activatedSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
+
+{ #category : #'api - activated session view model' }
+TGtWithActivatedSessionViewModel >> activatedSessionViewModel [
+	<return: #GtGemStoneSessionViewModel>
+	<propertyGetter: #activatedSessionViewModel>
+	<generatedFrom: #'TGtRobocoderWithPropertyTraitTemplate>>#propertyGetterTemplate'>
+
+	^ activatedSessionViewModel
+]
 
 { #category : #'api - activated session view model' }
 TGtWithActivatedSessionViewModel >> activateSessionViewModel: aNewActivatedSessionViewModel [
@@ -24,15 +33,6 @@ TGtWithActivatedSessionViewModel >> activateSessionViewModel: aNewActivatedSessi
 	activatedSessionViewModel := aNewActivatedSessionViewModel.
 	self onNewActivatedSessionViewModelSet: aNewActivatedSessionViewModel.
 	self notifyActivatedSessionViewModelChanged
-]
-
-{ #category : #'api - activated session view model' }
-TGtWithActivatedSessionViewModel >> activatedSessionViewModel [
-	<return: #GtGemStoneSessionViewModel>
-	<propertyGetter: #activatedSessionViewModel>
-	<generatedFrom: #'TGtRobocoderWithPropertyTraitTemplate>>#propertyGetterTemplate'>
-
-	^ activatedSessionViewModel
 ]
 
 { #category : #'api - activated session view model' }

--- a/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSession.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSession.trait.st
@@ -3,7 +3,7 @@ Trait {
 	#instVars : [
 		'gemStoneSession'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
 
 { #category : #'api - gem stone session' }

--- a/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionManagerViewModel.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionManagerViewModel.trait.st
@@ -3,7 +3,7 @@ Trait {
 	#instVars : [
 		'gemStoneSessionManagerViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
 
 { #category : #'api - gem stone session manager view model' }

--- a/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionRegistry.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionRegistry.trait.st
@@ -3,7 +3,7 @@ Trait {
 	#instVars : [
 		'gemStoneSessionRegistry'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
 
 { #category : #'api - gem stone session registry' }

--- a/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionViewModel.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionViewModel.trait.st
@@ -3,7 +3,7 @@ Trait {
 	#instVars : [
 		'gemStoneSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
 
 { #category : #'api - gem stone session view model' }

--- a/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionsViewModel.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithGemStoneSessionsViewModel.trait.st
@@ -3,7 +3,7 @@ Trait {
 	#instVars : [
 		'gemStoneSessionsViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
 
 { #category : #'api - gem stone sessions view model' }

--- a/src/GToolkit-GemStone-Pharo/TGtWithSelectedSessionViewModel.trait.st
+++ b/src/GToolkit-GemStone-Pharo/TGtWithSelectedSessionViewModel.trait.st
@@ -3,7 +3,7 @@ Trait {
 	#instVars : [
 		'selectedSessionViewModel'
 	],
-	#category : #'GToolkit-GemStone-Pharo-Support'
+	#category : 'GToolkit-GemStone-Pharo-Support'
 }
 
 { #category : #'api - selected session view model' }
@@ -52,6 +52,15 @@ TGtWithSelectedSessionViewModel >> onPreviousSelectedSessionViewModelUnset: aPre
 ]
 
 { #category : #'api - selected session view model' }
+TGtWithSelectedSessionViewModel >> selectedSessionViewModel [
+	<return: #GtGemStoneSessionViewModel>
+	<propertyGetter: #selectedSessionViewModel>
+	<generatedFrom: #'TGtRobocoderWithPropertyTraitTemplate>>#propertyGetterTemplate'>
+
+	^ selectedSessionViewModel
+]
+
+{ #category : #'api - selected session view model' }
 TGtWithSelectedSessionViewModel >> selectSessionViewModel: aNewSelectedSessionViewModel [
 	<propertySetter: #selectedSessionViewModel>
 	<generatedFrom: #'TGtRobocoderWithPropertyTraitTemplate>>#propertySetterTemplate'>
@@ -69,13 +78,4 @@ TGtWithSelectedSessionViewModel >> selectSessionViewModel: aNewSelectedSessionVi
 	selectedSessionViewModel := aNewSelectedSessionViewModel.
 	self onNewSelectedSessionViewModelSet: aNewSelectedSessionViewModel.
 	self notifySelectedSessionViewModelChanged
-]
-
-{ #category : #'api - selected session view model' }
-TGtWithSelectedSessionViewModel >> selectedSessionViewModel [
-	<return: #GtGemStoneSessionViewModel>
-	<propertyGetter: #selectedSessionViewModel>
-	<generatedFrom: #'TGtRobocoderWithPropertyTraitTemplate>>#propertyGetterTemplate'>
-
-	^ selectedSessionViewModel
 ]


### PR DESCRIPTION
 Fixed GspoString>>#limitedDisplayString to be coherent with the limit set in the guard. 

The limit of the guard is set to 10'000, but then when the string is copied, we only see the first 997 characters. Fixed it to show the first 9'997 characters.

Side note: I'm sorry about all the noise there is in this PR. I did everything in GT, and only selected the relevant change as you can see in the screenshot below 
<img width="3602" height="1904" alt="image" src="https://github.com/user-attachments/assets/909b6ac1-0ad3-46ef-8bed-0f6cd214c7bc" />
but I always get the noisy changes (I've tried 3 different times with different approaches, always with the same result.